### PR TITLE
Add "scope" entry

### DIFF
--- a/assets/pwa/manifest.json
+++ b/assets/pwa/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "My App",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "icons": [
     {


### PR DESCRIPTION
Here is my PR.
Please note, I wasn't able to install a PWA only on my side (tested on Macbook with macOS Sonoma, Chromium).
So after that I decided to deep dive into docs and I found that I forgot about `scope` entry (which is NOT crucial for making PWAs installable), but for some reason after adding that entry I've fixed the issue.
The scope attribute [limits](https://developer.mozilla.org/en-US/docs/Web/Manifest/scope) the navigation scope of PWA.
So I believe you can decide by yourself do you need this fix or not. As for me, I added that to my manifest and It just working fine.